### PR TITLE
Fix dashboard auth service undefined error

### DIFF
--- a/docs/js/auth.js
+++ b/docs/js/auth.js
@@ -388,9 +388,72 @@ class AuthManager {
   }
 }
 
+// Provide a global, early authService shim for legacy code paths
+if (typeof window !== 'undefined' && !window.authService) {
+  window.authService = {
+    isAuthenticated: () => {
+      try { return !!(window.authManager && window.authManager.isAuthenticated()); } catch { return false; }
+    },
+    getCurrentUser: () => {
+      try { return window.authManager && window.authManager.getCurrentUser(); } catch { return null; }
+    },
+    signInWithGoogle: () => {
+      if (window.authManager && typeof window.authManager.signInWithGoogle === 'function') {
+        return window.authManager.signInWithGoogle();
+      }
+    },
+    signIn: (email, password, rememberMe = false) => {
+      if (window.authManager && typeof window.authManager.signIn === 'function') {
+        return window.authManager.signIn(email, password, rememberMe);
+      }
+    },
+    signUp: (email, password, displayName) => {
+      if (window.authManager && typeof window.authManager.signUp === 'function') {
+        return window.authManager.signUp(email, password, displayName);
+      }
+    },
+    signOut: () => {
+      if (window.authManager && typeof window.authManager.signOut === 'function') {
+        return window.authManager.signOut();
+      }
+    }
+  };
+}
+
 // Initialize authentication manager when DOM is loaded
 document.addEventListener('DOMContentLoaded', () => {
   window.authManager = new AuthManager();
+  // Backwards compatibility shim for legacy code expecting `authService`
+  if (!window.authService) {
+    window.authService = {
+      isAuthenticated: () => {
+        try { return !!(window.authManager && window.authManager.isAuthenticated()); } catch { return false; }
+      },
+      getCurrentUser: () => {
+        try { return window.authManager && window.authManager.getCurrentUser(); } catch { return null; }
+      },
+      signInWithGoogle: () => {
+        if (window.authManager && typeof window.authManager.signInWithGoogle === 'function') {
+          return window.authManager.signInWithGoogle();
+        }
+      },
+      signIn: (email, password, rememberMe = false) => {
+        if (window.authManager && typeof window.authManager.signIn === 'function') {
+          return window.authManager.signIn(email, password, rememberMe);
+        }
+      },
+      signUp: (email, password, displayName) => {
+        if (window.authManager && typeof window.authManager.signUp === 'function') {
+          return window.authManager.signUp(email, password, displayName);
+        }
+      },
+      signOut: () => {
+        if (window.authManager && typeof window.authManager.signOut === 'function') {
+          return window.authManager.signOut();
+        }
+      }
+    };
+  }
 });
 
 // Export for use in other modules


### PR DESCRIPTION
Add `window.authService` compatibility shim to resolve `ReferenceError` in legacy code expecting it instead of `authManager`.

Older dashboard code, like `DashboardUI`, expected a global `authService` object. However, the current authentication logic is encapsulated in `window.authManager`. This PR introduces a proxy `authService` that forwards calls to `authManager`, ensuring backward compatibility and preventing runtime errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-54bc4e0f-2695-4ed8-8e10-189fdca4d197">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-54bc4e0f-2695-4ed8-8e10-189fdca4d197">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

